### PR TITLE
Fix left side Power Spot button in randbats calc

### DIFF
--- a/src/randoms.template.html
+++ b/src/randoms.template.html
@@ -881,7 +881,7 @@
                             <td><div class="left" title="Is the Pok&eacute;mon boosted by an ally's Power Spot ability?">
                                 <div hidden id="selectPowerSpotInstruction">Is the Pok&eacute;mon boosted by an ally's Power Spot ability?</div>
                                   <input aria-describedby="selectPowerSpotInstruction" class="visually-hidden calc-trigger" type="checkbox" id="powerSpotL" />
-                                  <label class="btn btn-xxwide" for="powerSpotR">Power Spot</label>
+                                  <label class="btn btn-xxwide" for="powerSpotL">Power Spot</label>
                                 </div></td>
                               <td><div class="right" title="Is the Pok&eacute;mon boosted by an ally's Power Spot ability?">
                                   <input aria-describedby="selectPowerSpotInstruction" class="visually-hidden calc-trigger" type="checkbox" id="powerSpotR" />


### PR DESCRIPTION
It was activating the right side button when pressed.